### PR TITLE
Added autoloader psr-0 definition to composer package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "ReactiveRaven/ColorJizz",
+    "name": "MischiefCollective/ColorJizz",
     "require": {},
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
added the extra bit to the package definition for generating the autoloader inside composer.

Needs registering on [packagist](http://packagist.org/) if you want to be able to require it in other projects without a custom repository specification.
