### PR TITLE
Type cast (int) where PHP8.x was complaining

### DIFF
--- a/src/MischiefCollective/ColorJizz/ColorJizz.php
+++ b/src/MischiefCollective/ColorJizz/ColorJizz.php
@@ -110,7 +110,7 @@ abstract class ColorJizz
         $a_dimension_pow = pow(($a->a_dimension - $b->a_dimension), 2);
         $b_dimension_pow = pow(($a->b_dimension - $b->b_dimension), 2);
 
-        return sqrt($lightness_pow + $a_dimension_pow + $b_dimension_pow);
+        return (int)sqrt($lightness_pow + $a_dimension_pow + $b_dimension_pow);
     }
 
     /**

--- a/src/MischiefCollective/ColorJizz/Formats/CMY.php
+++ b/src/MischiefCollective/ColorJizz/Formats/CMY.php
@@ -67,7 +67,7 @@ class CMY extends ColorJizz
      */
     public function getCyan()
     {
-        return $this->cyan;
+        return (int)$this->cyan;
     }
 
 
@@ -78,7 +78,7 @@ class CMY extends ColorJizz
      */
     public function getMagenta()
     {
-        return $this->magenta;
+        return (int)$this->magenta;
     }
 
 
@@ -89,7 +89,7 @@ class CMY extends ColorJizz
      */
     public function getYellow()
     {
-        return $this->yellow;
+        return (int)$this->yellow;
     }
 
 

--- a/src/MischiefCollective/ColorJizz/Formats/CMYK.php
+++ b/src/MischiefCollective/ColorJizz/Formats/CMYK.php
@@ -74,7 +74,7 @@ class CMYK extends ColorJizz
      */
     public function getCyan()
     {
-        return $this->cyan;
+        return (int)$this->cyan;
     }
 
 
@@ -85,7 +85,7 @@ class CMYK extends ColorJizz
      */
     public function getMagenta()
     {
-        return $this->magenta;
+        return (int)$this->magenta;
     }
 
 
@@ -96,7 +96,7 @@ class CMYK extends ColorJizz
      */
     public function getYellow()
     {
-        return $this->yellow;
+        return (int)$this->yellow;
     }
 
 
@@ -107,7 +107,7 @@ class CMYK extends ColorJizz
      */
     public function getKey()
     {
-        return $this->key;
+        return (int)$this->key;
     }
 
     /**

--- a/src/MischiefCollective/ColorJizz/Formats/RGB.php
+++ b/src/MischiefCollective/ColorJizz/Formats/RGB.php
@@ -72,7 +72,7 @@ class RGB extends ColorJizz
      */
     public function getRed()
     {
-        return (0.5 + $this->red) | 0;
+        return (int)(0.5 + $this->red) | 0;
     }
 
     /**
@@ -82,7 +82,7 @@ class RGB extends ColorJizz
      */
     public function getGreen()
     {
-        return (0.5 + $this->green) | 0;
+        return (int)(0.5 + $this->green) | 0;
     }
 
     /**
@@ -92,7 +92,7 @@ class RGB extends ColorJizz
      */
     public function getBlue()
     {
-        return (0.5 + $this->blue) | 0;
+        return (int)(0.5 + $this->blue) | 0;
     }
 
     /**


### PR DESCRIPTION
PHP's gotten stricter about type juggling and complained that converting from `float` to `int` causes imprecisions and that if one does it, it should be explicit. Not rigorously tested but seems to have fixed the Warnings in my usage.